### PR TITLE
[Fix] Ensure models are on eval mode when predicting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Types of changes
 * "Security" in case of vulnerabilities.
 -->
 
+## [Unreleased]
+
+### Changed
+
+- Ensure models are in evaluation mode when using `SpanMarkerModel.predict`.
+
 ## [1.0.1]
 
 ### Fixed

--- a/span_marker/modeling.py
+++ b/span_marker/modeling.py
@@ -368,6 +368,9 @@ class SpanMarkerModel(PreTrainedModel):
                 stacklevel=2,
             )
 
+        # Disable dropout, etc.
+        self.eval()
+
         if not inputs:
             return []
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Call `model.eval()` when using `SpanMarkerModel.predict`.

## Details
Otherwise, dropout may still be active. However, usually it won't be:
* Models are automatically on evaluation mode when loaded.
* Trainer.evaluate() also puts the model in evaluation mode.

With other words, it's not that big of an issue.

- Tom Aarsen