### PR TITLE
Improve speed of sample spreading - much faster inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Types of changes
 * "Security" in case of vulnerabilities.
 -->
 
+## [Unreleased]
+
+### Changed
+
+- Heavily improved computational efficiency of sample spreading, resulting in notably faster inference speeds.
+
 ## [1.1.1]
 
 ### Fixed

--- a/span_marker/tokenizer.py
+++ b/span_marker/tokenizer.py
@@ -43,7 +43,7 @@ class EntityTracker:
 
             with tokenizer.entity_tracker(split=dataset_name):
                 dataset = dataset.map(
-                    lambda batch: tokenizer(batch["tokens"], labels=batch["ner_tags"]),
+                    tokenizer,
                     ...
                 )
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Heavily improve speed of sample spreading.
  * Stop using lambda function in `dataset.map`, and
  * Increase the batch size from 1 to 1000 (the default for `dataset.map`) + a refactor of the spread sample method.

## Details
The goal for this PR is to only affect the computational speed. It makes two changes:

### Stop using lambda function in `dataset.map`
The `dataset.map` method will try to create a fingerprint of the method call based on all data regarding the call. If the function that you're calling with `dataset.map` is a lambda function however, then it has to include all `locals` into its fingerprinting method. In our case, this includes the full SpanMarker model. As a result, fingerprinting took ~2 seconds on my device, causing every bit of inference to take ~2 seconds.

### Increase the batch size from 1 to 1000
This speaks for itself - I've modified the sample spreading function to take batches rather than individual samples. 

## Results

Let's consider the following example:
```python
import time
from span_marker import SpanMarkerModel
from pprint import pprint

model = SpanMarkerModel.from_pretrained("tomaarsen/span-marker-bert-base-fewnerd-fine-super").cuda()

model.predict(["warmup"] * 100)

start_t = time.time()
entities = model.predict(
    [
    "Cleopatra VII, also known as Cleopatra the Great, was the last active ruler of the Ptolemaic Kingdom of Egypt.",
    "She was born in 69 BCE and ruled Egypt from 51 BCE until her death in 30 BCE."
    ]
)
pprint(entities)
print(f"{time.time() - start_t:.4f}s inference time")
```

### Before this PR
```python
1.9320s inference time
```

### After this PR
```python
0.0350s inference time
```

### For those curious
This was the output by the FewNERD model:
```python
[[{'char_end_index': 13,
   'char_start_index': 0,
   'label': 'person-politician',
   'score': 0.9018910527229309,
   'span': 'Cleopatra VII'},
  {'char_end_index': 48,
   'char_start_index': 29,
   'label': 'person-politician',
   'score': 0.8295162320137024,
   'span': 'Cleopatra the Great'},
  {'char_end_index': 109,
   'char_start_index': 104,
   'label': 'location-GPE',
   'score': 0.7120916247367859,
   'span': 'Egypt'}],
 [{'char_end_index': 38,
   'char_start_index': 33,
   'label': 'location-GPE',
   'score': 0.9808000326156616,
   'span': 'Egypt'}]]
```

I can easily reach ~60-70 sentences processed per second using a BERT-base model now.

- Tom Aarsen