### PR TITLE
Add `trained_with_document_context` to SpanMarkerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Types of changes
 
 ## [Unreleased]
 
+### Added
+
+- Added `trained_with_document_context` to the SpanMarkerConfig
+  - Added warnings if a model is trained with document-context and evaluated/inferenced without, or vice versa.
+
 ### Changed
 
 - Heavily improved computational efficiency of sample spreading, resulting in notably faster inference speeds.

--- a/span_marker/configuration.py
+++ b/span_marker/configuration.py
@@ -61,6 +61,7 @@ class SpanMarkerConfig(PretrainedConfig):
         self.entity_max_length = entity_max_length
         self.max_prev_context = max_prev_context
         self.max_next_context = max_next_context
+        self.trained_with_document_context = False
         self.span_marker_version = kwargs.pop("span_marker_version", None)
         super().__init__(**kwargs)
 

--- a/span_marker/modeling.py
+++ b/span_marker/modeling.py
@@ -369,12 +369,10 @@ class SpanMarkerModel(PreTrainedModel):
         from span_marker.trainer import Trainer
 
         if torch.cuda.is_available() and self.device == torch.device("cpu"):
-            warnings.warn(
+            logger.warn(
                 "SpanMarker model predictions are being computed on the CPU while CUDA is available."
                 " Moving the model to CUDA using `model.cuda()` before performing predictions is heavily"
                 " recommended to significantly boost prediction speeds.",
-                UserWarning,
-                stacklevel=2,
             )
 
         # Disable dropout, etc.
@@ -437,6 +435,11 @@ class SpanMarkerModel(PreTrainedModel):
             dataset = dataset.add_column(key, value)
         # Add context if possible
         if {"document_id", "sentence_id"} <= set(dataset.column_names):
+            if not self.config.trained_with_document_context:
+                logger.warning(
+                    "This model was trained without document-level context: "
+                    "inference with document-level context may cause decreased performance."
+                )
             # Add column to be able to revert sorting later
             dataset = dataset.add_column("__sort_id", range(len(dataset)))
             # Sorting by doc ID and then sentence ID is required for add_context
@@ -449,6 +452,11 @@ class SpanMarkerModel(PreTrainedModel):
             )
             dataset = dataset.sort(column_names=["__sort_id"])
             dataset = dataset.remove_columns("__sort_id")
+        elif self.config.trained_with_document_context:
+            logger.warning(
+                "This model was trained with document-level context: "
+                "inference without document-level context may cause decreased performance."
+            )
 
         dataset = dataset.map(
             Trainer.spread_sample,

--- a/span_marker/modeling.py
+++ b/span_marker/modeling.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import warnings
 from typing import Callable, Dict, List, Optional, Type, TypeVar, Union
 
 import torch


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add `trained_with_document_context` to SpanMarkerConfig.
* Add warnings if mismatch.
  * Plus tests.
* Update type hint for `trainer.model`.
* Change warnings.warning to logger.warn.

## Details
This parameter allows people to know how the model was trained: with or without document-level context. Additionally, it allows me to generate warnings if the a document-level context trained model is evaluated/inferenced without document-level context, or vice versa. I've added some tests that ensure that the warnings get sent out.

- Tom Aarsen