### PR TITLE
Tests: Reintroduce Windows tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Reintroduce Windows tests by cleaning up and recreating a temporary file.

## Details
The details are very complex and detailed, but after long sessions of debugging, I have found https://github.com/huggingface/transformers/commit/ebd94b0f6f215f6bc0f70e61eba075eb9196f9ef combined with pytest's same-seed-for-each-test policy with `datasets.disable_cache()` to be the combined culprits.

I hope I never run into this issue again.

- Tom Aarsen