### PR TITLE
Increase robustness of `is_split_into_words` check: resolves ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Types of changes
 ### Fixed
 
 - No longer override `language` metadata from the dataset if the language was also set manually via `SpanMarkerModelCardData`.
+- No longer crash on `predict` with `ValueError: Failed to concatenate on axis=1 ...` if the first sentence in a list of sentences is just one word.
 
 ## [1.4.0]
 

--- a/span_marker/tokenizer.py
+++ b/span_marker/tokenizer.py
@@ -180,10 +180,14 @@ class SpanMarkerTokenizer:
     ) -> Dict[str, List]:
         tokens = batch["tokens"]
         labels = batch.get("ner_tags", None)
-        # TODO: Increase robustness of this
         is_split_into_words = True
-        if isinstance(tokens, str) or (tokens and " " in tokens[0]):
+        if isinstance(tokens, str):
             is_split_into_words = False
+        elif tokens:
+            for token in tokens:
+                if " " in token:
+                    is_split_into_words = False
+                    break
 
         batch_encoding = self.tokenizer(
             tokens,

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -195,6 +195,13 @@ def test_correct_predictions_with_document_level_context(
     )
 
 
+def test_predict_where_first_sentence_is_word(finetuned_conll_span_marker_model: SpanMarkerModel) -> None:
+    model = finetuned_conll_span_marker_model.try_cuda()
+    outputs = model.predict(["One", "Two Three Four Five"])
+    assert len(outputs) == 2
+    assert isinstance(outputs[0], list)
+
+
 def test_incorrect_predict_inputs(finetuned_conll_span_marker_model: SpanMarkerModel):
     model = finetuned_conll_span_marker_model.try_cuda()
     with pytest.raises(ValueError, match="could not recognize your input"):


### PR DESCRIPTION
Closes #38, Closes #35

Hello!

## Pull Request overview
* Increase robustness of `is_split_into_words` check

## Details
In particular, before this PR, the tokenizer would use the first text in the prediction tokens to determine if we were dealing with: a string sentence, a list of string sentences, a sentence as a list of words, or a list of sentences each as a list of words. However, if the first sentence is just a single word, but you're passing a list of sentences, e.g. `['Avolon', 'Walmart - Milwaukee, WI']` or `["Unknown", "Unknown", "Unknown", "Sentence 1", "Sentence 2"]`, then it would consider the inputs to be a single sentence. 

With this PR, the tokenizer will see them as a list of sentences.

However, do watch out for the following case: a list of sentences where *each* sentence is a single word. This is indistinguishable from a sentence as a list of words, and it will (perhaps unexpectedly) consider the text as the latter. I don't see a good solution for this, apart from splitting `predict` up into `predict` and `predict_single` or something.

- Tom Aarsen