### PR TITLE
Improve the error when passing an empty sentence to the tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Types of changes
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the error when an empty sentence is provided to the tokenizer.
+
 ### Fixed
 
 - No longer override `language` metadata from the dataset if the language was also set manually via `SpanMarkerModelCardData`.

--- a/span_marker/tokenizer.py
+++ b/span_marker/tokenizer.py
@@ -202,7 +202,10 @@ class SpanMarkerTokenizer:
         all_labels = []
         all_num_words = []
         for sample_idx, input_ids in enumerate(batch_encoding["input_ids"]):
-            num_words = int(np.nanmax(np.array(batch_encoding.word_ids(sample_idx), dtype=float))) + 1
+            max_word_ids = np.nanmax(np.array(batch_encoding.word_ids(sample_idx), dtype=float))
+            if np.isnan(max_word_ids):
+                raise ValueError("The `SpanMarkerTokenizer` detected an empty sentence, please remove it.")
+            num_words = int(max_word_ids) + 1
             if self.tokenizer.pad_token_id in input_ids:
                 num_tokens = list(input_ids).index(self.tokenizer.pad_token_id)
             else:

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -202,6 +202,12 @@ def test_predict_where_first_sentence_is_word(finetuned_conll_span_marker_model:
     assert isinstance(outputs[0], list)
 
 
+def test_predict_empty_error(finetuned_conll_span_marker_model: SpanMarkerModel) -> None:
+    model = finetuned_conll_span_marker_model.try_cuda()
+    with pytest.raises(ValueError, match="The `SpanMarkerTokenizer` detected an empty sentence, please remove it."):
+        model.predict(["One Two", "Three Four Five", ""])
+
+
 def test_incorrect_predict_inputs(finetuned_conll_span_marker_model: SpanMarkerModel):
     model = finetuned_conll_span_marker_model.try_cuda()
     with pytest.raises(ValueError, match="could not recognize your input"):


### PR DESCRIPTION
Closes #33

Hello!

## Pull Request overview
* Improve the error when passing an empty sentence to the tokenizer
* + test

## Details
Before, if you provided an empty sentence to the tokenizer during training or predicting, you would get this error:
```python
from span_marker import SpanMarkerModel
model = SpanMarkerModel.from_pretrained("tomaarsen/span-marker-bert-base-fewnerd-fine-super")
entities = model.predict([""])
```
```
[sic]\span_marker\tokenizer.py:205: RuntimeWarning: All-NaN slice encountered
  num_words = int(np.nanmax(np.array(batch_encoding.word_ids(sample_idx), dtype=float))) + 1
Traceback (most recent call last):
  File "[sic]\demo_38.py", line 3, in <module>
    entities = model.predict([""])
  File "[sic]\span_marker\modeling.py", line 459, in predict
    tokenizer_dict = self.tokenizer(
  File "[sic]\span_marker\tokenizer.py", line 205, in __call__
    num_words = int(np.nanmax(np.array(batch_encoding.word_ids(sample_idx), dtype=float))) + 1
ValueError: cannot convert float NaN to integer
```
Now, you get the following error instead:
```
[sic]\span_marker\tokenizer.py:209: RuntimeWarning: All-NaN slice encountered
  max_word_ids = np.nanmax(np.array(batch_encoding.word_ids(sample_idx), dtype=float))
Traceback (most recent call last):
  File "[sic]\demo_38.py", line 3, in <module>
    entities = model.predict([""])
  File "[sic]\span_marker\modeling.py", line 459, in predict
    tokenizer_dict = self.tokenizer(
  File "[sic]\span_marker\tokenizer.py", line 211, in __call__
    raise ValueError("The `SpanMarkerTokenizer` detected an empty sentence, please remove it.")
ValueError: The `SpanMarkerTokenizer` detected an empty sentence, please remove it.
```

- Tom Aarsen