### PR TITLE
Warning update for evaluation done without document-level context

### DIFF
--- a/span_marker/trainer.py
+++ b/span_marker/trainer.py
@@ -240,7 +240,7 @@ class Trainer(TransformersTrainer):
             elif not self.model.config.trained_with_document_context:
                 logger.warning(
                     "This model was trained without document-level context: "
-                    "evaluation with document-level context may cause decreased performance."
+                    "evaluation without document-level context may cause decreased performance."
                 )
             dataset = dataset.sort(column_names=["document_id", "sentence_id"])
             dataset = self.add_context(


### PR DESCRIPTION
Without document - level context, ie., in the absence of `document_id` and `sentence_id` should throw the warning that evaluation without these metadata will decrease the performance.