### PR TITLE
handle removed DatasetFilter class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "evaluate",
     "seqeval",
     "jinja2",
-    "huggingface_hub"
+    "huggingface_hub>=0.24.0"
 ]
 dynamic = ["version"]
 

--- a/span_marker/model_card.py
+++ b/span_marker/model_card.py
@@ -13,13 +13,12 @@ import transformers
 from datasets import Dataset
 from huggingface_hub import (
     CardData,
-    DatasetFilter,
     ModelCard,
     dataset_info,
     list_datasets,
     model_info,
 )
-from huggingface_hub.repocard_data import EvalResult, eval_results_to_model_index
+from huggingface_hub.repocard_data import EvalResult,eval_results_to_model_index
 from huggingface_hub.utils import yaml_dump
 from transformers import TrainerCallback
 from transformers.integrations import CodeCarbonCallback
@@ -366,7 +365,7 @@ class SpanMarkerModelCardData(CardData):
             # Make sure the normalized dataset IDs match
             dataset_list = [
                 dataset
-                for dataset in list_datasets(filter=DatasetFilter(author=author, dataset_name=dataset_name))
+                for dataset in list_datasets(author=author, dataset_name=dataset_name)
                 if normalize(dataset.id) == normalize(cache_dataset_name)
             ]
             # If there's only one match, get the ID from it

--- a/span_marker/model_card.py
+++ b/span_marker/model_card.py
@@ -18,7 +18,7 @@ from huggingface_hub import (
     list_datasets,
     model_info,
 )
-from huggingface_hub.repocard_data import EvalResult,eval_results_to_model_index
+from huggingface_hub.repocard_data import EvalResult, eval_results_to_model_index
 from huggingface_hub.utils import yaml_dump
 from transformers import TrainerCallback
 from transformers.integrations import CodeCarbonCallback

--- a/tests/test_spacy_integration.py
+++ b/tests/test_spacy_integration.py
@@ -28,6 +28,7 @@ def test_span_marker_as_spacy_pipeline_component():
         ("Paris", "LOC"),
     ]
 
+
 def test_span_marker_as_spacy_pipeline_component_pipe():
     nlp = spacy.load("en_core_web_sm", disable=["ner"])
     batch_size = 2


### PR DESCRIPTION
Updates the usage of `list_datasets()` to not use the deprecated/removed `DatasetFilter` class

Also bumps the minimum version of `huggingface-hub` in dependencies 

Fixes https://github.com/tomaarsen/SpanMarkerNER/issues/64