### PR TITLE
[`deprecate`] Deprecate Python 3.8, resolve incompatibilities with updated dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "span_marker"
 description = "Named Entity Recognition using Span Markers"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "Apache-2.0"}
 keywords = [
     "data-science",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ maintainers = [
 dependencies = [
     "torch",
     "accelerate",
-    "transformers>=4.19.0", # required for EvalPrediction.inputs
+    "transformers>=4.19.0,<5", # required for EvalPrediction.inputs
     "datasets>=2.14.0", # required for sorting with multiple columns
     "packaging>=20.0",
     "evaluate",

--- a/span_marker/configuration.py
+++ b/span_marker/configuration.py
@@ -65,6 +65,9 @@ class SpanMarkerConfig(PretrainedConfig):
         self.span_marker_version = kwargs.pop("span_marker_version", None)
         super().__init__(**kwargs)
 
+        if not self.encoder:
+            return
+
         # label2id and id2label are automatically set by super().__init__, but we want to rely on
         # the encoder configs instead if we can, so we delete them under two conditions
         # 1. if they're the default ({0: "LABEL_0", 1: "LABEL_1"})

--- a/tests/model_card_pattern.py
+++ b/tests/model_card_pattern.py
@@ -6,22 +6,20 @@ MODEL_CARD_PATTERN = re.compile(
 language:
 - en
 license: apache-2\.0
-library_name: span-marker
 tags:
 - span-marker
 - token-classification
 - ner
 - named-entity-recognition
 - generated_from_span_marker_trainer
-datasets:
-- conll2003
+widget:
+- text: .*
+pipeline_tag: token-classification
+library_name: span-marker
 metrics:
 - precision
 - recall
 - f1
-widget:
-- text: .*
-pipeline_tag: token-classification
 co2_eq_emissions:
   emissions: [\d\.\-e]+
   source: codecarbon
@@ -31,7 +29,9 @@ co2_eq_emissions:
   ram_total_size: [\d\.]+
   hours_used: [\d\.]+
 (  hardware_used: .+
-)?base_model: prajjwal1/bert-tiny
+)?datasets:
+- conll2003
+base_model: prajjwal1/bert-tiny
 model-index:
 - name: SpanMarker with prajjwal1/bert-tiny on CoNLL 2003
   results:
@@ -155,7 +155,7 @@ trainer.save_model\("tomaarsen/span-marker-test-model-card-finetuned"\)
 - train_batch_size: 1
 - eval_batch_size: 8
 - seed: 42
-- optimizer: Adam with betas=\(0.9,0.999\) and epsilon=1e-08
+- optimizer: Use adamw_torch with betas=\(0\.9,0\.999\) and epsilon=1e-08 and optimizer_args=No additional optimizer arguments
 - lr_scheduler_type: linear
 - num_epochs: 1
 

--- a/tests/model_card_pattern.py
+++ b/tests/model_card_pattern.py
@@ -155,7 +155,7 @@ trainer.save_model\("tomaarsen/span-marker-test-model-card-finetuned"\)
 - train_batch_size: 1
 - eval_batch_size: 8
 - seed: 42
-- optimizer: Use adamw_torch with betas=\(0\.9,0\.999\) and epsilon=1e-08 and optimizer_args=No additional optimizer arguments
+- optimizer: Use (OptimizerNames.ADAMW_TORCH|adamw_torch) with betas=\(0\.9,0\.999\) and epsilon=1e-08 and optimizer_args=No additional optimizer arguments
 - lr_scheduler_type: linear
 - num_epochs: 1
 

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -49,7 +49,6 @@ def test_model_card(fewnwerd_coarse_dataset_dict: DatasetDict, tmp_path: Path) -
     )
     trainer.train()
     model_card = generate_model_card(trainer.model)
-    print(model_card)
     assert MODEL_CARD_PATTERN.fullmatch(model_card)
 
 

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -49,6 +49,7 @@ def test_model_card(fewnwerd_coarse_dataset_dict: DatasetDict, tmp_path: Path) -
     )
     trainer.train()
     model_card = generate_model_card(trainer.model)
+    print(model_card)
     assert MODEL_CARD_PATTERN.fullmatch(model_card)
 
 

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -103,10 +103,10 @@ def test_is_on_huggingface_edge_case() -> None:
     assert not is_on_huggingface("a/test/value")
 
 
-@pytest.mark.parametrize("dataset_id", ("conll2003", "tomaarsen/conll2003"))
+@pytest.mark.parametrize("dataset_id", ("eriktks/conll2003", "tomaarsen/conll2003"))
 def test_infer_dataset_id(dataset_id: str) -> None:
     model = SpanMarkerModel.from_pretrained(TINY_BERT, labels=CONLL_LABELS)
-    train_dataset = load_dataset(dataset_id, split="train")
+    train_dataset = load_dataset(dataset_id, split="train", trust_remote_code=True)
 
     # This triggers inferring the dataset_id from train_dataset
     Trainer(model=model, train_dataset=train_dataset)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Deprecate Python 3.8

## Details
Python 3.8 has reached its end of life, so we're deprecating it.

- Tom Aarsen