### PR TITLE
Use getattr instead of __getattribute__ to get tokenizer args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ maintainers = [
 dependencies = [
     "torch",
     "accelerate",
-    "transformers>=4.19.0,<5", # required for EvalPrediction.inputs
+    "transformers>=4.23.0,<5", # required for EvalPrediction.inputs
     "datasets>=2.14.0", # required for sorting with multiple columns
     "packaging>=20.0",
     "evaluate",

--- a/span_marker/tokenizer.py
+++ b/span_marker/tokenizer.py
@@ -173,7 +173,7 @@ class SpanMarkerTokenizer:
         try:
             return super().__getattribute__(key)
         except AttributeError:
-            return super().__getattribute__("tokenizer").__getattribute__(key)
+            return getattr(super().__getattribute__("tokenizer"), key)
 
     def __call__(
         self, batch: Dict[str, List[Any]], return_num_words: bool = False, return_batch_encoding=False, **kwargs


### PR DESCRIPTION
Resolves #70

Hello!

## Pull Request overview
* Use getattr instead of __getattribute__ to get tokenizer args

## Details
It seems that `__getattribute__` does not work anymore, likely due to an update on the `transformers` side in 4.47.X where they (also) started using a bit of a hackish approach for exposing the `pad_token_id` attribute.

- Tom Aarsen