### PR TITLE
Fixes #82: add upper version bounds for transformers and datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ maintainers = [
 dependencies = [
     "torch",
     "accelerate",
-    "transformers>=4.23.0,<5", # required for EvalPrediction.inputs
-    "datasets>=2.14.0", # required for sorting with multiple columns
+    "transformers>=4.23.0,<=4.50.0", # required for EvalPrediction.inputs # Added upper bound related to Issue 82
+    "datasets>=2.14.0,<=3.0.0", # required for sorting with multiple columns # Added upper bound related to Issue 82
     "packaging>=20.0",
     "evaluate",
     "seqeval",


### PR DESCRIPTION
## Summary
Fixes #82 — adds upper-bound version constraints for `transformers` and `datasets`
to prevent breaking changes in recent releases.

## Details
- Updated dependency range in `pyproject.toml`:
  - `transformers>=4.23.0,<=4.50.0`
  - `datasets>=2.14.0,<=3.0.0`
- Commented the rationale directly in the file.
- Tested with SpanMarker 1.7.0 on Python 3.12.

## Validation
✅ model loads successfully with `transformers==4.50.0`  
✅ `model.predict()` works on notebook example  
⚠️ Newer `transformers` versions (≥4.57.0) remain incompatible, pending upstream update.

---

Closes #82
