### PR TITLE
Resolve compatibility issues, drop Python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,53 +21,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Try to load cached dependencies
-        uses: actions/cache@v3
-        id: restore-cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ env.pythonLocation }}
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
 
-      - name: Install external dependencies on cache miss
+      - name: Install dependencies
         run: |
-          python -m pip install --no-cache-dir --upgrade pip
-          python -m pip install --no-cache-dir ".[dev, codecarbon]"
+          uv pip install --system ".[dev, codecarbon]"
           python -m spacy download en_core_web_sm
-        if: steps.restore-cache.outputs.cache-hit != 'true'
 
       - name: Install the checked-out span_marker
-        run: python -m pip install .
-
-      - name: Restore HF models from cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cache/huggingface/hub
-            ~/.cache/torch
-          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
-          restore-keys: |
-            hf-models-${{ matrix.os }}-
+        run: uv pip install --system .
 
       - name: Run unit tests
-        shell: bash
-        run: |
-          echo "OLD_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-          pytest -sv
-          echo "NEW_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-
-      - name: Save new HF models to cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ~/.cache/huggingface/hub
-            ~/.cache/torch
-          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
-        # Only save cache if the hash has changed
-        if: env.NEW_HF_CACHE_HASH != env.OLD_HF_CACHE_HASH
+        run: pytest -sv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ def main() -> None:
         # Other Training parameters
         logging_first_step=True,
         logging_steps=50,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         save_strategy="steps",
         eval_steps=3000,
         save_total_limit=2,

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
     "    per_device_train_batch_size=4,\n",
     "    per_device_eval_batch_size=4,\n",
     "    num_train_epochs=1,\n",
-    "    evaluation_strategy=\"steps\",\n",
+    "    eval_strategy=\"steps\",  # Or `evaluation_strategy` if your `transformers<4.54.1`=\"steps\",\n",
     "    save_strategy=\"steps\",\n",
     "    eval_steps=200,\n",
     "    push_to_hub=False,\n",
@@ -683,7 +683,7 @@
     "        per_device_train_batch_size=4,\n",
     "        per_device_eval_batch_size=4,\n",
     "        num_train_epochs=1,\n",
-    "        evaluation_strategy=\"steps\",\n",
+    "        eval_strategy=\"steps\",  # Or `evaluation_strategy` if your `transformers<4.54.1`\n",
     "        save_strategy=\"steps\",\n",
     "        eval_steps=200,\n",
     "        push_to_hub=False,\n",

--- a/notebooks/model_training.ipynb
+++ b/notebooks/model_training.ipynb
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
     "    per_device_train_batch_size=4,\n",
     "    per_device_eval_batch_size=4,\n",
     "    num_train_epochs=1,\n",
-    "    evaluation_strategy=\"steps\",\n",
+    "    eval_strategy=\"steps\",  # Or `evaluation_strategy` if your `transformers<4.54.1`\n",
     "    save_strategy=\"steps\",\n",
     "    eval_steps=500,\n",
     "    push_to_hub=False,\n",
@@ -551,7 +551,7 @@
     "        per_device_train_batch_size=4,\n",
     "        per_device_eval_batch_size=4,\n",
     "        num_train_epochs=1,\n",
-    "        evaluation_strategy=\"steps\",\n",
+    "        eval_strategy=\"steps\",  # Or `evaluation_strategy` if your `transformers<4.54.1`\n",
     "        save_strategy=\"steps\",\n",
     "        eval_steps=500,\n",
     "        push_to_hub=False,\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "span_marker"
 description = "Named Entity Recognition using Span Markers"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 keywords = [
     "data-science",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "torch",
     "accelerate",
     "transformers>=4.23.0,<5", # required for EvalPrediction.inputs
-    "datasets>=2.14.0", # required for sorting with multiple columns
+    "datasets>=2.20.0", # required to solve AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'. Did you mean: 'ExtensionType'?
     "packaging>=20.0",
     "evaluate",
     "seqeval",

--- a/span_marker/configuration.py
+++ b/span_marker/configuration.py
@@ -114,7 +114,10 @@ class SpanMarkerConfig(PretrainedConfig):
             return super().__getattribute__(key)
         except AttributeError as e:
             try:
-                return super().__getattribute__("encoder")[key]
+                encoder = super().__getattribute__("encoder")
+                if encoder is None:
+                    raise e
+                return encoder[key]
             except KeyError:
                 raise e
 

--- a/span_marker/modeling.py
+++ b/span_marker/modeling.py
@@ -457,7 +457,7 @@ class SpanMarkerModel(PreTrainedModel):
 
         # Tokenize & add start/end markers
         tokenizer_dict = self.tokenizer(
-            {"tokens": dataset["tokens"]}, return_num_words=True, return_batch_encoding=True
+            {"tokens": list(dataset["tokens"])}, return_num_words=True, return_batch_encoding=True
         )
         batch_encoding = tokenizer_dict.pop("batch_encoding")
         dataset = dataset.remove_columns("tokens")

--- a/span_marker/modeling.py
+++ b/span_marker/modeling.py
@@ -311,7 +311,7 @@ class SpanMarkerModel(PreTrainedModel):
         # Since transformers 4.32.0 we should use `pad_to_multiple_of=8`.
         # That'll fail for earlier versions, so we try-except it.
         try:
-            model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8)
+            model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8, mean_resizing=False)
         except TypeError:
             model.resize_token_embeddings(len(tokenizer))
         return model

--- a/span_marker/modeling.py
+++ b/span_marker/modeling.py
@@ -251,9 +251,14 @@ class SpanMarkerModel(PreTrainedModel):
         """
         # If loading a SpanMarkerConfig, then we don't want to override id2label and label2id
         # Create an encoder or SpanMarker config
+        # Pop `dtype` before passing to AutoConfig, as it's a model loading parameter
+        # that would otherwise override the config's saved dtype with the string "auto"
+        dtype = kwargs.pop("dtype", None)
         config: PretrainedConfig = config or AutoConfig.from_pretrained(
             pretrained_model_name_or_path, *model_args, **kwargs
         )
+        if dtype is not None:
+            kwargs["dtype"] = dtype
 
         # if 'pretrained_model_name_or_path' refers to a SpanMarkerModel instance, initialize it directly
         loading_span_marker = isinstance(config, cls.config_class)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -122,6 +122,6 @@ FABNER_LABELS = [
     "E-BIOP",
     "S-BIOP",
 ]
-TINY_BERT = "prajjwal1/bert-tiny"
+TINY_BERT = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
 
 DEFAULT_ARGS = TrainingArguments(output_dir="models/my_span_marker_model", report_to="none", num_train_epochs=1)

--- a/tests/model_card_pattern.py
+++ b/tests/model_card_pattern.py
@@ -155,7 +155,7 @@ trainer.save_model\("tomaarsen/span-marker-test-model-card-finetuned"\)
 - train_batch_size: 1
 - eval_batch_size: 8
 - seed: 42
-- optimizer: Use (OptimizerNames.ADAMW_TORCH|adamw_torch) with betas=\(0\.9,0\.999\) and epsilon=1e-08 and optimizer_args=No additional optimizer arguments
+- optimizer: Use (OptimizerNames.ADAMW_TORCH_FUSED|OptimizerNames.ADAMW_TORCH|adamw_torch_fused|adamw_torch) with betas=\(0\.9,0\.999\) and epsilon=1e-08 and optimizer_args=No additional optimizer arguments
 - lr_scheduler_type: linear
 - num_epochs: 1
 

--- a/tests/model_card_pattern.py
+++ b/tests/model_card_pattern.py
@@ -33,7 +33,7 @@ co2_eq_emissions:
 - conll2003
 base_model: sentence-transformers-testing/stsb-bert-tiny-safetensors
 model-index:
-- name: SpanMarker with sentence-transformers-testing/stsb-bert-tiny-safetensors on CoNLL 2003
+- name: SpanMarker with sentence-transformers-testing/stsb-bert-tiny-safetensors on\n    CoNLL 2003
   results:
   - task:
       type: token-classification

--- a/tests/model_card_pattern.py
+++ b/tests/model_card_pattern.py
@@ -31,9 +31,9 @@ co2_eq_emissions:
 (  hardware_used: .+
 )?datasets:
 - conll2003
-base_model: prajjwal1/bert-tiny
+base_model: sentence-transformers-testing/stsb-bert-tiny-safetensors
 model-index:
-- name: SpanMarker with prajjwal1/bert-tiny on CoNLL 2003
+- name: SpanMarker with sentence-transformers-testing/stsb-bert-tiny-safetensors on CoNLL 2003
   results:
   - task:
       type: token-classification
@@ -54,15 +54,15 @@ model-index:
       name: Recall
 ---
 
-# SpanMarker with prajjwal1/bert-tiny on CoNLL 2003
+# SpanMarker with sentence-transformers-testing/stsb-bert-tiny-safetensors on CoNLL 2003
 
-This is a \[SpanMarker\]\(https://github.com/tomaarsen/SpanMarkerNER\) model trained on the \[CoNLL 2003\]\(https://huggingface.co/datasets/conll2003\) dataset that can be used for Named Entity Recognition. This SpanMarker model uses \[prajjwal1/bert-tiny\]\(https://huggingface.co/prajjwal1/bert-tiny\) as the underlying encoder.
+This is a \[SpanMarker\]\(https://github.com/tomaarsen/SpanMarkerNER\) model trained on the \[CoNLL 2003\]\(https://huggingface.co/datasets/conll2003\) dataset that can be used for Named Entity Recognition. This SpanMarker model uses \[sentence-transformers-testing/stsb-bert-tiny-safetensors\]\(https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors\) as the underlying encoder.
 
 ## Model Details
 
 ### Model Description
 - \*\*Model Type:\*\* SpanMarker
-- \*\*Encoder:\*\* \[prajjwal1/bert-tiny\]\(https://huggingface.co/prajjwal1/bert-tiny\)
+- \*\*Encoder:\*\* \[sentence-transformers-testing/stsb-bert-tiny-safetensors\]\(https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors\)
 - \*\*Maximum Sequence Length:\*\* 512 tokens
 - \*\*Maximum Entity Length:\*\* 8 words
 - \*\*Training Dataset:\*\* \[CoNLL 2003\]\(https://huggingface.co/datasets/conll2003\)

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -38,7 +38,7 @@ def test_model_card(fewnwerd_coarse_dataset_dict: DatasetDict, tmp_path: Path) -
         report_to="codecarbon",
         eval_steps=1,
         per_device_train_batch_size=1,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         num_train_epochs=1,
     )
     trainer = Trainer(
@@ -103,10 +103,11 @@ def test_is_on_huggingface_edge_case() -> None:
     assert not is_on_huggingface("a/test/value")
 
 
-@pytest.mark.parametrize("dataset_id", ("eriktks/conll2003", "tomaarsen/conll2003"))
+# "eriktks/conll2003" uses dataset loading scripts, removed from `datasets` >= 4.0.
+@pytest.mark.parametrize("dataset_id", ("tomaarsen/conll2003",))
 def test_infer_dataset_id(dataset_id: str) -> None:
     model = SpanMarkerModel.from_pretrained(TINY_BERT, labels=CONLL_LABELS)
-    train_dataset = load_dataset(dataset_id, split="train", trust_remote_code=True)
+    train_dataset = load_dataset(dataset_id, split="train")
 
     # This triggers inferring the dataset_id from train_dataset
     Trainer(model=model, train_dataset=train_dataset)

--- a/training_scripts/conll03_context.py
+++ b/training_scripts/conll03_context.py
@@ -47,7 +47,7 @@ def main() -> None:
         # Other Training parameters
         logging_first_step=True,
         logging_steps=50,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         save_strategy="steps",
         eval_steps=1000,
         save_total_limit=2,

--- a/training_scripts/conll03_no_context.py
+++ b/training_scripts/conll03_no_context.py
@@ -46,7 +46,7 @@ def main() -> None:
         # Other Training parameters
         logging_first_step=True,
         logging_steps=50,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         save_strategy="steps",
         eval_steps=1000,
         save_total_limit=2,

--- a/training_scripts/conllpp_context.py
+++ b/training_scripts/conllpp_context.py
@@ -47,7 +47,7 @@ def main() -> None:
         # Other Training parameters
         logging_first_step=True,
         logging_steps=50,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         save_strategy="steps",
         eval_steps=1000,
         save_total_limit=2,

--- a/training_scripts/fewnerd_base.py
+++ b/training_scripts/fewnerd_base.py
@@ -47,7 +47,7 @@ def main() -> None:
         # Other Training parameters
         logging_first_step=True,
         logging_steps=50,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         save_strategy="steps",
         eval_steps=3000,
         save_total_limit=2,

--- a/training_scripts/fewnerd_large.py
+++ b/training_scripts/fewnerd_large.py
@@ -47,7 +47,7 @@ def main() -> None:
         # Other Training parameters
         logging_first_step=True,
         logging_steps=50,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         save_strategy="steps",
         eval_steps=3000,
         save_total_limit=2,

--- a/training_scripts/ontonotesv5.py
+++ b/training_scripts/ontonotesv5.py
@@ -85,7 +85,7 @@ def main() -> None:
         # Other Training parameters
         logging_first_step=True,
         logging_steps=50,
-        evaluation_strategy="steps",
+        eval_strategy="steps",  # Or `evaluation_strategy` if your `transformers<4.54.1`
         save_strategy="steps",
         eval_steps=1000,
         save_total_limit=2,


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increment min. Python version to 3.10
* Simplify CI, remove caching, use uv
* Fix compatibility issues with `transformers` and `datasets` 4.x

## Details
I increment the min. version of Python to 3.10, and worked to resolve the compatibility issues that have accumulated. Specifically, `SpanMarkerConfig.__getattribute__`: when `self.encoder` is `None` (e.g. during config construction), the fallback `self.encoder[key]` raised `TypeError: 'NoneType' object is not subscriptable`. This surfaced because `transformers` 4.57 accesses new internal config attributes like `_attn_implementation_internal` that trigger the fallback path. I added a `None` guard before subscripting.

Two other `transformers` 4.57 changes needed fixes:
- `evaluation_strategy` was removed from `TrainingArguments` in favor of `eval_strategy` — updated everywhere (code, training scripts, notebooks, tests).
- `pipeline()` now passes `dtype="auto"` to `from_pretrained`. This leaked into `AutoConfig.from_pretrained` where it overwrote the saved config's `dtype` (a `torch.dtype`) with the string `"auto"`, which then failed in `_set_default_dtype`. Fixed by popping `dtype` from kwargs before the `AutoConfig` call and restoring it after.

On the `datasets` 4.x side:
- `dataset["column"]` now returns a `Column` object instead of a plain `list`, which the HF tokenizer rejects. Fixed by wrapping in `list()` in the predict path.
- `eriktks/conll2003` uses loading scripts which are no longer supported. `tomaarsen/conll2003` was reuploaded as Parquet, so that test now loads without `trust_remote_code`.
- The default optimizer changed to `ADAMW_TORCH_FUSED`, so I updated the model card test pattern.

---

- Tom Aarsen