### PR TITLE
[`security`] Strip trust_remote_code from inner encoder config

### DIFF
--- a/span_marker/modeling.py
+++ b/span_marker/modeling.py
@@ -77,7 +77,9 @@ class SpanMarkerModel(PreTrainedModel):
             # Load the encoder via the Config to prevent having to use AutoModel.from_pretrained, which
             # could load e.g. all of `roberta-large` from the Hub unnecessarily.
             # However, use the SpanMarkerModel updated vocab_size
-            encoder_config = AutoConfig.from_pretrained(self.config.encoder["_name_or_path"], **self.config.encoder)
+            # Also strip trust_remote_code from configuration. See https://github.com/tomaarsen/SpanMarkerNER/issues/85
+            encoder_kwargs = {k: v for k, v in self.config.encoder.items() if k not in ("trust_remote_code",)}
+            encoder_config = AutoConfig.from_pretrained(self.config.encoder["_name_or_path"], **encoder_kwargs)
             encoder = AutoModel.from_config(encoder_config)
         self.encoder = encoder
 

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Union
 import pytest
 import torch
 from datasets import Dataset
+from transformers import AutoConfig
 
 from span_marker.configuration import SpanMarkerConfig
 from span_marker.modeling import SpanMarkerModel
@@ -235,6 +236,27 @@ def test_load_with_kwargs(kwargs) -> None:
     # We only test that the model can be loaded without issues
     model = SpanMarkerModel.from_pretrained(TINY_BERT, labels=CONLL_LABELS, kwargs=kwargs)
     assert isinstance(model, SpanMarkerModel)
+
+
+def test_trust_remote_code_stripped_from_encoder_config(fresh_conll_span_marker_model: SpanMarkerModel) -> None:
+    """Test that trust_remote_code is stripped from the encoder config to prevent
+    a two-repository attack. See https://github.com/tomaarsen/SpanMarkerNER/issues/85
+    """
+    model = fresh_conll_span_marker_model
+    # Inject trust_remote_code into the encoder config, as a malicious config.json would
+    model.config.encoder["trust_remote_code"] = True
+
+    from unittest.mock import patch
+
+    with patch(
+        "span_marker.modeling.AutoConfig.from_pretrained", wraps=AutoConfig.from_pretrained
+    ) as mock_from_pretrained:
+        SpanMarkerModel(model.config)
+        mock_from_pretrained.assert_called_once()
+        call_kwargs = mock_from_pretrained.call_args
+        # trust_remote_code must not be passed through
+        assert "trust_remote_code" not in call_kwargs.kwargs
+        assert "trust_remote_code" not in (call_kwargs.args[1:] if len(call_kwargs.args) > 1 else ())
 
 
 def test_try_cuda(finetuned_conll_span_marker_model: SpanMarkerModel) -> None:


### PR DESCRIPTION
Resolves #85

Hello!

## Pull Request overview
* Strip `trust_remote_code` from encoder config before passing it to `AutoConfig.from_pretrained`
* Add test to verify `trust_remote_code` is not forwarded

## Details
As reported in #85, the encoder config loaded from a remote `config.json` was splatted directly into `AutoConfig.from_pretrained`. This allowed a two-repository attack where a malicious model publishes a `config.json` with `trust_remote_code: true` pointing to an attacker-controlled encoder repository, achieving arbitrary code execution on `SpanMarkerModel.from_pretrained`.

The fix filters out `trust_remote_code` from the encoder kwargs dict before forwarding it. The test injects `trust_remote_code` into a model's encoder config and verifies via a mock that it doesn't reach `AutoConfig.from_pretrained`.

- Tom Aarsen
